### PR TITLE
add soundscrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A curated list of open source tools for archiving audio & video data for offline usage.
 
 ## Command-line apps
-* [youtube-dl](https://github.com/rg3/youtube-dl/) Archive audio & video from sites like YouTube & Soundcloud
+* [youtube-dl](https://github.com/rg3/youtube-dl/) Archive audio & video from sites like YouTube & SoundCloud
 * [download-m3u8](https://github.com/mafintosh/download-m3u8/) Download an m3u8 playlist and all assets it links
 * [instavim](https://github.com/codedotjs/instavim) Download videos available on Instagram directly from command line
+* [soundscrape](https://github.com/Miserlou/SoundScrape) Download audio (with metadata & album art) from SoundCloud, Bandcamp, and MixCloud


### PR DESCRIPTION
I've found [SoundScrape](https://github.com/Miserlou/SoundScrape) to be very useful for backing up tracks from SoundCloud, especially since SoundCloud's future is unclear. Also supports Bandcamp and MixCloud, and adds metadata and album art to downloaded audio.

I've been using it to populate test libraries for [Hyperamp](https://github.com/hypermodules/hyperamp) quite a bit.